### PR TITLE
Modernize, implement HTTP auth

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <extension>
+        <groupId>io.jenkins.tools.incrementals</groupId>
+        <artifactId>git-changelist-maven-extension</artifactId>
+        <version>1.4</version>
+    </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pmight-produce-incrementals
+-Pconsume-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532</version>
+    <version>4.76</version>
   </parent>
 
   <artifactId>git-userContent</artifactId>
@@ -15,7 +15,11 @@
   <description>
     This plugin manages JENKINS_HOME/userContent under Git
   </description>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Git+userContent+Plugin</url>
+  <url>https://github.com/jenkinsci/git-userContent-plugin</url>
+
+  <properties>
+    <jenkins.version>2.361.4</jenkins.version>
+  </properties>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
@@ -25,8 +29,7 @@
   <licenses>
     <license>
       <name>The MIT license</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
-      <distribution>repo</distribution>
+      <url>https://www.opensource.org/licenses/mit</url>
     </license>
   </licenses>
 
@@ -34,21 +37,26 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>sshd</artifactId>
-      <version>1.1</version>
-      <scope>provided</scope><!-- this is in the core -->
+      <version>3.322.v159e91f6a_550</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-server</artifactId>
-      <version>1.6</version>
+      <version>115.v132fd6e5777a_</version>
     </dependency>
   </dependencies>
 
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/gitUserContent/GitUserContentRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/gitUserContent/GitUserContentRepository.java
@@ -1,13 +1,19 @@
 package org.jenkinsci.plugins.gitUserContent;
 
 import hudson.Extension;
-import hudson.model.RootAction;
+import hudson.model.UnprotectedRootAction;
+import hudson.security.ACL;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
 import org.jenkinsci.main.modules.sshd.SSHD;
 import org.jenkinsci.plugins.gitserver.FileBackedHttpGitRepository;
 
 import javax.inject.Inject;
 import java.io.File;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * Exposes Git repository at http://server/jenkins/userContent.git
@@ -15,7 +21,7 @@ import java.io.File;
  * @author Kohsuke Kawaguchi
  */
 @Extension
-public class GitUserContentRepository extends FileBackedHttpGitRepository implements RootAction {
+public class GitUserContentRepository extends FileBackedHttpGitRepository implements UnprotectedRootAction {
     @Inject
     public SSHD sshd;
 
@@ -38,5 +44,16 @@ public class GitUserContentRepository extends FileBackedHttpGitRepository implem
 
     public String getUrlName() {
         return "userContent.git";
+    }
+
+    @Override
+    public void doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+        if (!Jenkins.get().hasPermission(Jenkins.READ) && ACL.isAnonymous2(Jenkins.getAuthentication2())) {
+            rsp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            rsp.setHeader("WWW-Authenticate", "Basic realm=\"Jenkins user\"");
+            return;
+        }
+        Jenkins.get().checkPermission(Jenkins.READ);
+        super.doDynamic(req, rsp);
     }
 }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    This plugin manages JENKINS_HOME/userContent under Git.
+</div>


### PR DESCRIPTION
Demonstrates how one could implement an authentication challenge for HTTP Git repos, addressing https://github.com/jenkinsci/git-server-plugin/pull/112#issuecomment-1910331712:

> my distant memory of it is that HTTP mode is essentially useless because it does not support authentication at all and so is only appropriate for an unsecured controller


Minimal testing and requires the linked PR for a `git clone`, would not consider this to be production code. Probably better off integrated properly in `git-server`.